### PR TITLE
PROBLEM: Including in c++ project breaks linkage

### DIFF
--- a/lua.h
+++ b/lua.h
@@ -12,6 +12,9 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #include "luaconf.h"
 
@@ -482,5 +485,8 @@ struct lua_Debug {
 * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ******************************************************************************/
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
SOLUTION: Wrap main include header file with conditional `extern "C" {
... }` so that others don't have to manually wrap `lua.h`, i.e.:
```
extern "C" {
  #include <lua.h>
}
```