### PR TITLE
Allowing implicit nil in setmetatable

### DIFF
--- a/lbaselib.c
+++ b/lbaselib.c
@@ -123,13 +123,13 @@ static int luaB_getmetatable (lua_State *L) {
 
 
 static int luaB_setmetatable (lua_State *L) {
+  lua_settop(L, 2);
   int t = lua_type(L, 2);
   luaL_checktype(L, 1, LUA_TTABLE);
   luaL_argcheck(L, t == LUA_TNIL || t == LUA_TTABLE, 2,
                     "nil or table expected");
   if (luaL_getmetafield(L, 1, "__metatable") != LUA_TNIL)
     return luaL_error(L, "cannot change a protected metatable");
-  lua_settop(L, 2);
   lua_setmetatable(L, 1);
   return 1;
 }


### PR DESCRIPTION
`setmetatable(t)` now functions identically to `setmetatable(t, nil)` instead of returning an argument type error.