### PR TITLE
fix os_execute compile error on ios

### DIFF
--- a/loslib.c
+++ b/loslib.c
@@ -137,8 +137,18 @@ static time_t l_checktime (lua_State *L, int arg) {
 
 
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#define __IOS__
+#endif
+#endif
 
 static int os_execute (lua_State *L) {
+#if defined(__IOS__)
+  lua_pushboolean(L, 0);
+  return 1;
+#else
   const char *cmd = luaL_optstring(L, 1, NULL);
   int stat = system(cmd);
   if (cmd != NULL)
@@ -147,6 +157,7 @@ static int os_execute (lua_State *L) {
     lua_pushboolean(L, stat);  /* true if there is a shell */
     return 1;
   }
+#endif
 }
 
 


### PR DESCRIPTION
ios project xcodebuild error
loslib.c 'system' is unavailable: not available on iOS
