### PR TITLE
fix clang compile warnings

### DIFF
--- a/lbitlib.c
+++ b/lbitlib.c
@@ -4,4 +4,4 @@
 ** See Copyright Notice in lua.h
 */
 
-Deprecated module.
+//Deprecated module.

--- a/lvm.c
+++ b/lvm.c
@@ -36,7 +36,9 @@
 ** and compatible compilers.
 */
 #if !defined(LUA_USE_JUMPTABLE)
-#define LUA_USE_JUMPTABLE	defined(__GNUC__)
+#if defined(__GNUC__)
+#define LUA_USE_JUMPTABLE
+#endif
 #endif
 
 


### PR DESCRIPTION
Use `clang *.c` can simple build the project!
only with warning:
 ``` 
lvm.c:884:5: warning: macro expansion producing "defined" has undefined behavior [-Wexpansion-to-defined]
#if LUA_USE_JUMPTABLE
    ^
lvm.c:39:27: note: expanded from macro "LUA_USE_JUMPTABLE"
#define LUA_USE_JUMPTABLE       defined(__GNUC__)
                                ^
1 warning generated.
```
So with this small fix, there is even no warning(on Windows)!