### PR TITLE
Missing v5-2-4 tag

### DIFF
--- a/repo_request.txt
+++ b/repo_request.txt
@@ -1,0 +1,1 @@
+Could you push version 5.2.4 released on 25 Feb 2015, to this GitHub mirror with proper tag?


### PR DESCRIPTION
Could you push version 5.2.4 released on 25 Feb 2015, to this GitHub mirror with proper tag?