### PR TITLE
Remove #include lstate from ltm to break circular includes

### DIFF
--- a/ltm.h
+++ b/ltm.h
@@ -9,7 +9,6 @@
 
 
 #include "lobject.h"
-#include "lstate.h"
 
 
 /*


### PR DESCRIPTION
ltm.h #includes lstate.h and lstate.h #includes ltm.h.

lstate.h uses TM_N from ltm.h and lstate.h uses nothing from ltm.h