### PR TITLE
overflow in implicit constant conversion

### DIFF
--- a/lauxlib.h
+++ b/lauxlib.h
@@ -118,7 +118,11 @@ LUALIB_API void (luaL_requiref) (lua_State *L, const char *modname,
 
 
 #define luaL_newlibtable(L,l)	\
-  lua_createtable(L, 0, sizeof(l)/sizeof((l)[0]) - 1)
+// lua/lauxlib.h:109:53: error: overflow in implicit constant conversion [-Werror=overflow]
+// It happened on MinGW(TDM-GCC), Windows7 64bit
+// gcc -O2 -g -Werror -Wall -Wextra
+//lua_createtable(L, 0, sizeof(l)/sizeof((l)[0]) - 1)
+  lua_createtable(L, 0, (int)(sizeof(l)/sizeof((l)[0]) - 1))  // looks everything fine
 
 #define luaL_newlib(L,l)  \
   (luaL_checkversion(L), luaL_newlibtable(L,l), luaL_setfuncs(L,l,0))
@@ -252,5 +256,3 @@ typedef struct luaL_Stream {
 
 
 #endif
-
-


### PR DESCRIPTION
lua/lauxlib.h:109:53: error: overflow in implicit constant conversion [-Werror=overflow]
It happened on MinGW(TDM-GCC), Windows7 64bit.
compiler args: -O2 -g -Werror -Wall -Wextra

The complete project:
https://github.com/ToyAuthor/luapp/