### PR TITLE
Fix Lua test suite when built in POSIX mode

### DIFF
--- a/testes/main.lua
+++ b/testes/main.lua
@@ -298,6 +298,9 @@ assert(string.find(t, prompt .. ".*" .. prompt .. ".*" .. prompt))
 
 
 -- non-string prompt
+--
+-- if readline is linked then termios will echo the input.
+-- otherwise only the numeric prompt is printed.
 prompt =
   "local C = 0;\z
    _PROMPT=setmetatable({},{__tostring = function () \z
@@ -311,7 +314,7 @@ assert(string.find(t, [[
 1 --
 2a = 2
 3
-]], 1, true))
+]], 1, true) or string.find(t, "123", 1, true))
 
 
 -- test for error objects


### PR DESCRIPTION
This change enables the test suite to pass when libreadline isn't
linked. It's not clear if this is the intended behavior since Lua
might have intended to manually echo or otherwise omit the prompt