### PR TITLE
Add launch.json and update CFLAGS in makefile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  // Use o IntelliSense para saber mais sobre os atributos possíveis.
+  // Focalizar para exibir as descrições dos atributos existentes.
+  // Para obter mais informações, acesse: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "(gdb) Iniciar",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/lua",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${fileDirname}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "setupCommands": [
+        {
+          "description": "Habilitar a reformatação automática para gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Definir Tipo de Desmontagem como Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/makefile
+++ b/makefile
@@ -76,7 +76,7 @@ MYLIBS= -ldl -lreadline
 
 
 CC= gcc
-CFLAGS= -Wall -O2 $(MYCFLAGS) -fno-stack-protector -fno-common -march=native
+CFLAGS= -Wall -g -O2 $(MYCFLAGS) -fno-stack-protector -fno-common -march=native
 AR= ar rc
 RANLIB= ranlib
 RM= rm -f


### PR DESCRIPTION
Adicionei essa configuração para permitir que o código de lua possa ser depuravel no vscode usando gdb.

### Como usar ?

1. Build o projeto com make. Obs: (*Para o gdb conseguir ler o pontos de paradas tem que ser especificado para o compilador a flag -g*)
2. Depois vá no vscode -> `Ctrl + Shift + D` -> `F5`
3. Basta colocar o breakpoint onde você quiser debugar.

Exemplo: 
![image](https://github.com/lua/lua/assets/83548040/8e569716-31c4-4196-b038-f910b90ce789)
