### PR TITLE
Fix various typos

### DIFF
--- a/ldo.c
+++ b/ldo.c
@@ -513,7 +513,7 @@ l_sinline void genmoveresults (lua_State *L, StkId res, int nres,
 ** to 'res'.  Handle most typical cases (zero results for commands,
 ** one result for expressions, multiple results for tail calls/single
 ** parameters) separated. The flag CIST_TBC in 'fwanted', if set,
-** forces the swicth to go to the default case.
+** forces the switch to go to the default case.
 */
 l_sinline void moveresults (lua_State *L, StkId res, int nres,
                                           l_uint32 fwanted) {

--- a/lparser.c
+++ b/lparser.c
@@ -563,7 +563,7 @@ static void closegoto (LexState *ls, int g, Labeldesc *label, int bup) {
 
 /*
 ** Search for an active label with the given name, starting at
-** index 'ilb' (so that it can searh for all labels in current block
+** index 'ilb' (so that it can search for all labels in current block
 ** or all labels in current function).
 */
 static Labeldesc *findlabel (LexState *ls, TString *name, int ilb) {

--- a/lvm.c
+++ b/lvm.c
@@ -327,7 +327,7 @@ lu_byte luaV_finishget (lua_State *L, const TValue *t, TValue *key,
 ** Finish a table assignment 't[key] = val'.
 ** About anchoring the table before the call to 'luaH_finishset':
 ** This call may trigger an emergency collection. When loop>0,
-** the table being acessed is a field in some metatable. If this
+** the table being accessed is a field in some metatable. If this
 ** metatable is weak and the table is not anchored, this collection
 ** could collect that table while it is being updated.
 */

--- a/testes/api.lua
+++ b/testes/api.lua
@@ -114,7 +114,7 @@ end
 
 -- testing warnings
 T.testC([[
-  warningC "#This shold be a"
+  warningC "#This should be a"
   warningC " single "
   warning "warning"
   warningC "#This should be "
@@ -162,7 +162,7 @@ do  -- test returning more results than fit in the caller stack
 end
 
 
-do  -- testing multipe returns
+do  -- testing multiple returns
   local function foo (n)
     if n > 0 then return n, foo(n - 1) end
   end
@@ -902,7 +902,7 @@ F = function (x)
     assert(T.udataval(A) == B)
     debug.getmetatable(A)    -- just access it
   end
-  A = x   -- ressurect userdata
+  A = x   -- resurrect userdata
   B = udval
   return 1,2,3
 end

--- a/testes/constructs.lua
+++ b/testes/constructs.lua
@@ -60,7 +60,7 @@ assert((x>y) and x or y == 2);
 
 assert(1234567890 == tonumber('1234567890') and 1234567890+1 == 1234567891)
 
-do   -- testing operators with diffent kinds of constants
+do   -- testing operators with different kinds of constants
   -- operands to consider:
   --  * fit in register
   --  * constant doesn't fit in register

--- a/testes/db.lua
+++ b/testes/db.lua
@@ -431,7 +431,7 @@ do
   assert(a == nil and not b)
 end
 
--- testing iteraction between multiple values x hooks
+-- testing interaction between multiple values x hooks
 do
   local function f(...) return 3, ... end
   local count = 0
@@ -587,7 +587,7 @@ t = getupvalues(foo2)
 assert(t.a == 1 and t.b == 2 and t.c == 3)
 assert(debug.setupvalue(foo1, 1, "xuxu") == "b")
 assert(({debug.getupvalue(foo2, 3)})[2] == "xuxu")
--- upvalues of C functions are allways "called" "" (the empty string)
+-- upvalues of C functions are always "called" "" (the empty string)
 assert(debug.getupvalue(string.gmatch("x", "x"), 1) == "")  
 
 
@@ -839,7 +839,7 @@ t[1] = "'error'"
 checktraceback(co, t)
 
 
--- test acessing line numbers of a coroutine from a resume inside
+-- test accessing line numbers of a coroutine from a resume inside
 -- a C function (this is a known bug in Lua 5.0)
 
 local function g(x)
@@ -966,9 +966,9 @@ local debug = require'debug'
 local a = 12  -- a local variable
 
 local n, v = debug.getlocal(1, 1)
-assert(n == "(temporary)" and v == debug)   -- unkown name but known value
+assert(n == "(temporary)" and v == debug)   -- unknown name but known value
 n, v = debug.getlocal(1, 2)
-assert(n == "(temporary)" and v == 12)   -- unkown name but known value
+assert(n == "(temporary)" and v == 12)   -- unknown name but known value
 
 -- a function with an upvalue
 local f = function () local x; return a end
@@ -1018,7 +1018,7 @@ do   -- bug in 5.4.0: line hooks in stripped code
     line = l
   end, "l")
   assert(s() == 2); debug.sethook(nil)
-  assert(line == nil)  -- hook called withoug debug info for 1st instruction
+  assert(line == nil)  -- hook called without debug info for 1st instruction
 end
 
 do   -- tests for 'source' in binary dumps

--- a/testes/errors.lua
+++ b/testes/errors.lua
@@ -507,7 +507,7 @@ end
 
 
 if not _soft then
-  -- several tests that exaust the Lua stack
+  -- several tests that exhaust the Lua stack
   collectgarbage()
   print"testing stack overflow"
   local C = 0

--- a/testes/files.lua
+++ b/testes/files.lua
@@ -478,7 +478,7 @@ do print("testing flush")
 end
 
 
--- test for multipe arguments in 'lines'
+-- test for multiple arguments in 'lines'
 io.output(file); io.write"0123456789\n":close()
 for a,b in io.lines(file, 1, 1) do
   if a == "\n" then assert(not b)

--- a/testes/gc.lua
+++ b/testes/gc.lua
@@ -446,8 +446,8 @@ do   -- tests for string keys in weak tables
   local m = collectgarbage("count")         -- current memory
   local a = setmetatable({}, {__mode = "kv"})
   a[string.rep("a", 2^22)] = 25   -- long string key -> number value
-  a[string.rep("b", 2^22)] = {}   -- long string key -> colectable value
-  a[{}] = 14                     -- colectable key
+  a[string.rep("b", 2^22)] = {}   -- long string key -> collectable value
+  a[{}] = 14                     -- collectable key
   collectgarbage()
   local k, v = next(a)   -- string key with number value preserved
   assert(k == string.rep("a", 2^22) and v == 25)
@@ -459,7 +459,7 @@ do   -- tests for string keys in weak tables
   assert(next(a) == nil)
   -- make sure will not try to compare with dead key
   assert(a[string.rep("b", 100)] == undef)
-  assert(collectgarbage("count") <= m + 1)   -- eveything collected
+  assert(collectgarbage("count") <= m + 1)   -- everything collected
 end
 
 
@@ -524,7 +524,7 @@ do
     local co = coroutine.create(f)
     assert(coroutine.resume(co, co))
   end
-  -- Now, thread and closure are not reacheable any more.
+  -- Now, thread and closure are not reachable any more.
   collectgarbage()
   assert(collected)
   collectgarbage("restart")
@@ -644,7 +644,7 @@ do
     assert(getmetatable(o) == tt)
     -- create new objects during GC
     local a = 'xuxu'..(10+3)..'joao', {}
-    ___Glob = o  -- ressurrect object!
+    ___Glob = o  -- resurrect object!
     setmetatable({}, tt)  -- creates a new one with same metatable
     print(">>> closing state " .. "<<<\n")
   end

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -1162,7 +1162,7 @@ do
   local function open (x)
     numopen = numopen + 1
     return
-      function ()   -- iteraction function
+      function ()   -- interaction function
         x = x - 1
         if x > 0 then return x end
       end,

--- a/testes/main.lua
+++ b/testes/main.lua
@@ -226,7 +226,7 @@ RUN("lua -l 'str=string' '-lm=math' -e 'print(m.sin(0))' %s > %s", prog, out)
 checkout("0.0\nALO ALO\t20\n")
 
 
--- test module names with version sufix ("libs/lib2-v2")
+-- test module names with version suffix ("libs/lib2-v2")
 RUN("env LUA_CPATH='./libs/?.so' lua -l lib2-v2 -e 'print(lib2.id())' > %s",
     out)
 checkout("true\n")
@@ -347,7 +347,7 @@ checkout("a\n")
 RUN([[lua "-eprint(1)" -ea=3 -e "print(a)" > %s]], out)
 checkout("1\n3\n")
 
--- test iteractive mode
+-- test interactive mode
 prepfile[[
 (6*2-6) -- ===
 a =

--- a/testes/math.lua
+++ b/testes/math.lua
@@ -1071,7 +1071,7 @@ do
     assert(x == tonumber(tostring(x)))
   end
 
-  -- different numbers shold print differently.
+  -- different numbers should print differently.
   -- check pairs of floats with minimum detectable difference
   local p = floatbits - 1
   for i = 1, maxexp - 1 do

--- a/testes/nextvar.lua
+++ b/testes/nextvar.lua
@@ -227,7 +227,7 @@ for i = 1,lim do
 end
 
 
--- insert and delete elements until a rehash occurr. Caller must ensure
+-- insert and delete elements until a rehash occur. Caller must ensure
 -- that a rehash will change the shape of the table. Must repeat because
 -- the insertion may collide with the deleted element, and then there is
 -- no rehash.
@@ -349,7 +349,7 @@ a,b,c = 1,2,3
 a,b,c = nil
 
 
--- next uses always the same iteraction function
+-- next uses always the same interaction function
 assert(next{} == next{})
 
 local function find (name)

--- a/testes/pm.lua
+++ b/testes/pm.lua
@@ -23,9 +23,9 @@ a,b = string.find('alo', '')
 assert(a == 1 and b == 0)
 a,b = string.find('a\0o a\0o a\0o', 'a', 1)   -- first position
 assert(a == 1 and b == 1)
-a,b = string.find('a\0o a\0o a\0o', 'a\0o', 2)   -- starts in the midle
+a,b = string.find('a\0o a\0o a\0o', 'a\0o', 2)   -- starts in the middle
 assert(a == 5 and b == 7)
-a,b = string.find('a\0o a\0o a\0o', 'a\0o', 9)   -- starts in the midle
+a,b = string.find('a\0o a\0o a\0o', 'a\0o', 9)   -- starts in the middle
 assert(a == 9 and b == 11)
 a,b = string.find('a\0a\0a\0a\0\0ab', '\0ab', 2);  -- finds at the end
 assert(a == 9 and b == 11);

--- a/testes/utf8.lua
+++ b/testes/utf8.lua
@@ -134,7 +134,7 @@ do
   errorcodes("\xbfinvalid")
   errorcodes("αλφ\xBFα")
 
-  -- calling interation function with invalid arguments
+  -- calling interaction function with invalid arguments
   local f = utf8.codes("")
   assert(f("", 2) == nil)
   assert(f("", -1) == nil)


### PR DESCRIPTION
Found via `codespell -q 3 -L alo,allo,checkk,checkklist,nd,ot,siz,totalin`